### PR TITLE
Update Bob's Logistics translation key

### DIFF
--- a/locale/cs/locale.cfg
+++ b/locale/cs/locale.cfg
@@ -4,12 +4,12 @@ vanilla-loaders-hd=Základní nákladače
 [mod-description]
 
 [entity-name]
-basic-loader=Základní nakladač
+bob-basic-loader=Základní nakladač
 
 ub-ultra-fast-loader=Ultra rychlý malý nakladač
 
 [item-name]
-basic-loader=Základní nakladač
+bob-basic-loader=Základní nakladač
 
 ub-ultra-fast-loader=Ultra rychlý malý nakladač
 

--- a/locale/cs/locale.cfg
+++ b/locale/cs/locale.cfg
@@ -4,20 +4,14 @@ vanilla-loaders-hd=Základní nákladače
 [mod-description]
 
 [entity-name]
-bob-turbo-loader=Turbo nakladač
-bob-ultimate-loader=Ultimátní nakladač
 basic-loader=Základní nakladač
 
 ub-ultra-fast-loader=Ultra rychlý malý nakladač
-ub-ultimate-loader=Ultimátní nakladač
 
 [item-name]
-bob-turbo-loader=Turbo nakladač
-bob-ultimate-loader=Ultimátní nakladač
 basic-loader=Základní nakladač
 
 ub-ultra-fast-loader=Ultra rychlý malý nakladač
-ub-ultimate-loader=Ultimátní nakladač
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Přepracování receptů

--- a/locale/cs/locale.cfg
+++ b/locale/cs/locale.cfg
@@ -4,14 +4,20 @@ vanilla-loaders-hd=Základní nákladače
 [mod-description]
 
 [entity-name]
+bob-turbo-loader=Turbo nakladač
+bob-ultimate-loader=Ultimátní nakladač
 bob-basic-loader=Základní nakladač
 
 ub-ultra-fast-loader=Ultra rychlý malý nakladač
+ub-ultimate-loader=Ultimátní nakladač
 
 [item-name]
+bob-turbo-loader=Turbo nakladač
+bob-ultimate-loader=Ultimátní nakladač
 bob-basic-loader=Základní nakladač
 
 ub-ultra-fast-loader=Ultra rychlý malý nakladač
+ub-ultimate-loader=Ultimátní nakladač
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Přepracování receptů

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -4,7 +4,7 @@ vanilla-loaders-hd=Vanilla Belader
 [mod-description]
 
 [entity-name]
-basic-loader=Einfacher Belader
+bob-basic-loader=Einfacher Belader
 
 ub-ultra-fast-loader=Ultraschneller Belader
 ub-extreme-fast-loader=Extrem schneller Belader
@@ -12,7 +12,7 @@ ub-ultra-express-loader=Ultra Express-Belader
 ub-extreme-express-loader=Extrem Express-Belader
 
 [item-name]
-basic-loader=Einfacher Belader
+bob-basic-loader=Einfacher Belader
 
 ub-ultra-fast-loader=Ultraschneller Belader
 ub-extreme-fast-loader=Extrem schneller Belader

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -4,20 +4,26 @@ vanilla-loaders-hd=Vanilla Belader
 [mod-description]
 
 [entity-name]
+bob-turbo-loader=Turbo-Belader
+bob-ultimate-loader=Ultimativer Belader
 bob-basic-loader=Einfacher Belader
 
 ub-ultra-fast-loader=Ultraschneller Belader
 ub-extreme-fast-loader=Extrem schneller Belader
 ub-ultra-express-loader=Ultra Express-Belader
 ub-extreme-express-loader=Extrem Express-Belader
+ub-ultimate-loader=Ultimativer Belader
 
 [item-name]
+bob-turbo-loader=Turbo-Belader
+bob-ultimate-loader=Ultimativer Belader
 bob-basic-loader=Einfacher Belader
 
 ub-ultra-fast-loader=Ultraschneller Belader
 ub-extreme-fast-loader=Extrem schneller Belader
 ub-ultra-express-loader=Ultra Express-Belader
 ub-extreme-express-loader=Extrem Express-Belader
+ub-ultimate-loader=Ultimativer Belader
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Überarbeitung der Baupläne

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -4,26 +4,20 @@ vanilla-loaders-hd=Vanilla Belader
 [mod-description]
 
 [entity-name]
-bob-turbo-loader=Turbo-Belader
-bob-ultimate-loader=Ultimativer Belader
 basic-loader=Einfacher Belader
 
 ub-ultra-fast-loader=Ultraschneller Belader
 ub-extreme-fast-loader=Extrem schneller Belader
 ub-ultra-express-loader=Ultra Express-Belader
 ub-extreme-express-loader=Extrem Express-Belader
-ub-ultimate-loader=Ultimativer Belader
 
 [item-name]
-bob-turbo-loader=Turbo-Belader
-bob-ultimate-loader=Ultimativer Belader
 basic-loader=Einfacher Belader
 
 ub-ultra-fast-loader=Ultraschneller Belader
 ub-extreme-fast-loader=Extrem schneller Belader
 ub-ultra-express-loader=Ultra Express-Belader
 ub-extreme-express-loader=Extrem Express-Belader
-ub-ultimate-loader=Ultimativer Belader
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Überarbeitung der Baupläne

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -7,7 +7,7 @@ vanilla-loaders-hd=Adds the vanilla loaders to the game with customizable recipe
 [entity-name]
 bob-turbo-loader=Turbo loader
 bob-ultimate-loader=Ultimate loader
-basic-loader=Basic loader
+bob-basic-loader=Basic loader
 
 ub-ultra-fast-loader=Ultra fast loader
 ub-extreme-fast-loader=Extreme fast loader
@@ -18,7 +18,7 @@ ub-ultimate-loader=Ultimate loader
 [item-name]
 bob-turbo-loader=Turbo loader
 bob-ultimate-loader=Ultimate loader
-basic-loader=Basic loader
+bob-basic-loader=Basic loader
 
 ub-ultra-fast-loader=Ultra fast loader
 ub-extreme-fast-loader=Extreme fast loader

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -4,18 +4,12 @@ vanilla-loaders-hd=Chargeurs Vanille
 [mod-description]
 
 [entity-name]
-bob-turbo-loader=Chargeur turbo
-bob-ultimate-loader=Chargeur ultime
 basic-loader=Chargeur basique
 
-ub-ultimate-loader=Chargeur ultime
 
 [item-name]
-bob-turbo-loader=Chargeur turbo
-bob-ultimate-loader=Chargeur ultime
 basic-loader=Chargeur basique
 
-ub-ultimate-loader=Chargeur ultime
 
 [mod-setting-name]
 

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -4,12 +4,18 @@ vanilla-loaders-hd=Chargeurs Vanille
 [mod-description]
 
 [entity-name]
+bob-turbo-loader=Chargeur turbo
+bob-ultimate-loader=Chargeur ultime
 bob-basic-loader=Chargeur basique
 
+ub-ultimate-loader=Chargeur ultime
 
 [item-name]
+bob-turbo-loader=Chargeur turbo
+bob-ultimate-loader=Chargeur ultime
 bob-basic-loader=Chargeur basique
 
+ub-ultimate-loader=Chargeur ultime
 
 [mod-setting-name]
 

--- a/locale/fr/locale.cfg
+++ b/locale/fr/locale.cfg
@@ -4,11 +4,11 @@ vanilla-loaders-hd=Chargeurs Vanille
 [mod-description]
 
 [entity-name]
-basic-loader=Chargeur basique
+bob-basic-loader=Chargeur basique
 
 
 [item-name]
-basic-loader=Chargeur basique
+bob-basic-loader=Chargeur basique
 
 
 [mod-setting-name]

--- a/locale/it/locale.cfg
+++ b/locale/it/locale.cfg
@@ -4,18 +4,12 @@ vanilla-loaders-hd=Caricatori Vanilla
 [mod-description]
 
 [entity-name]
-bob-turbo-loader=Caricatore turbo
-bob-ultimate-loader=Caricatore definitivo
 basic-loader=Caricatore di base
 
-ub-ultimate-loader=Caricatore definitivo
 
 [item-name]
-bob-turbo-loader=Caricatore turbo
-bob-ultimate-loader=Caricatore definitivo
 basic-loader=Caricatore di base
 
-ub-ultimate-loader=Caricatore definitivo
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Revisione ricetta

--- a/locale/it/locale.cfg
+++ b/locale/it/locale.cfg
@@ -4,11 +4,11 @@ vanilla-loaders-hd=Caricatori Vanilla
 [mod-description]
 
 [entity-name]
-basic-loader=Caricatore di base
+bob-basic-loader=Caricatore di base
 
 
 [item-name]
-basic-loader=Caricatore di base
+bob-basic-loader=Caricatore di base
 
 
 [mod-setting-name]

--- a/locale/it/locale.cfg
+++ b/locale/it/locale.cfg
@@ -4,12 +4,18 @@ vanilla-loaders-hd=Caricatori Vanilla
 [mod-description]
 
 [entity-name]
+bob-turbo-loader=Caricatore turbo
+bob-ultimate-loader=Caricatore definitivo
 bob-basic-loader=Caricatore di base
 
+ub-ultimate-loader=Caricatore definitivo
 
 [item-name]
+bob-turbo-loader=Caricatore turbo
+bob-ultimate-loader=Caricatore definitivo
 bob-basic-loader=Caricatore di base
 
+ub-ultimate-loader=Caricatore definitivo
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Revisione ricetta

--- a/locale/nl/locale.cfg
+++ b/locale/nl/locale.cfg
@@ -5,20 +5,26 @@ vanilla-loaders-hd=Vanilla Laders
 vanilla-loaders-hd=Voegt de vanilla laders toe aan het spel met aanpasbare receptmoeilijkheid. Ondersteunt transportbanden toegevoegd door Bob's Logistiek en Ultimate Belts.
 
 [entity-name]
+bob-turbo-loader=Turbo lader
+bob-ultimate-loader=Ultieme lader
 bob-basic-loader=Basis lader
 
 ub-ultra-fast-loader=Ultrasnelle lader
 ub-extreme-fast-loader=Extreme snelle lader
 ub-ultra-express-loader=Ultra snelle lader
 ub-extreme-express-loader=Extreme snelle lader
+ub-ultimate-loader=Ultieme lader
 
 [item-name]
+bob-turbo-loader=Turbo lader
+bob-ultimate-loader=Ultieme lader
 bob-basic-loader=Basis lader
 
 ub-ultra-fast-loader=Ultrasnelle lader
 ub-extreme-fast-loader=Extreme snelle lader
 ub-ultra-express-loader=Ultra snelle lader
 ub-extreme-express-loader=Extreme snelle lader
+ub-ultimate-loader=Ultieme lader
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Recept revisie

--- a/locale/nl/locale.cfg
+++ b/locale/nl/locale.cfg
@@ -5,26 +5,20 @@ vanilla-loaders-hd=Vanilla Laders
 vanilla-loaders-hd=Voegt de vanilla laders toe aan het spel met aanpasbare receptmoeilijkheid. Ondersteunt transportbanden toegevoegd door Bob's Logistiek en Ultimate Belts.
 
 [entity-name]
-bob-turbo-loader=Turbo lader
-bob-ultimate-loader=Ultieme lader
 basic-loader=Basis lader
 
 ub-ultra-fast-loader=Ultrasnelle lader
 ub-extreme-fast-loader=Extreme snelle lader
 ub-ultra-express-loader=Ultra snelle lader
 ub-extreme-express-loader=Extreme snelle lader
-ub-ultimate-loader=Ultieme lader
 
 [item-name]
-bob-turbo-loader=Turbo lader
-bob-ultimate-loader=Ultieme lader
 basic-loader=Basis lader
 
 ub-ultra-fast-loader=Ultrasnelle lader
 ub-extreme-fast-loader=Extreme snelle lader
 ub-ultra-express-loader=Ultra snelle lader
 ub-extreme-express-loader=Extreme snelle lader
-ub-ultimate-loader=Ultieme lader
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Recept revisie

--- a/locale/nl/locale.cfg
+++ b/locale/nl/locale.cfg
@@ -5,7 +5,7 @@ vanilla-loaders-hd=Vanilla Laders
 vanilla-loaders-hd=Voegt de vanilla laders toe aan het spel met aanpasbare receptmoeilijkheid. Ondersteunt transportbanden toegevoegd door Bob's Logistiek en Ultimate Belts.
 
 [entity-name]
-basic-loader=Basis lader
+bob-basic-loader=Basis lader
 
 ub-ultra-fast-loader=Ultrasnelle lader
 ub-extreme-fast-loader=Extreme snelle lader
@@ -13,7 +13,7 @@ ub-ultra-express-loader=Ultra snelle lader
 ub-extreme-express-loader=Extreme snelle lader
 
 [item-name]
-basic-loader=Basis lader
+bob-basic-loader=Basis lader
 
 ub-ultra-fast-loader=Ultrasnelle lader
 ub-extreme-fast-loader=Extreme snelle lader

--- a/locale/pl/locale.cfg
+++ b/locale/pl/locale.cfg
@@ -4,11 +4,11 @@ vanilla-loaders-hd=Klasyczna ładowarka
 [mod-description]
 
 [entity-name]
-basic-loader=Podstawowa ładowarka
+bob-basic-loader=Podstawowa ładowarka
 
 
 [item-name]
-basic-loader=Podstawowa ładowarka
+bob-basic-loader=Podstawowa ładowarka
 
 
 [mod-setting-name]

--- a/locale/pl/locale.cfg
+++ b/locale/pl/locale.cfg
@@ -4,12 +4,10 @@ vanilla-loaders-hd=Klasyczna ładowarka
 [mod-description]
 
 [entity-name]
-bob-turbo-loader=Turbo ładowarka
 basic-loader=Podstawowa ładowarka
 
 
 [item-name]
-bob-turbo-loader=Turbo ładowarka
 basic-loader=Podstawowa ładowarka
 
 

--- a/locale/pl/locale.cfg
+++ b/locale/pl/locale.cfg
@@ -4,10 +4,12 @@ vanilla-loaders-hd=Klasyczna ładowarka
 [mod-description]
 
 [entity-name]
+bob-turbo-loader=Turbo ładowarka
 bob-basic-loader=Podstawowa ładowarka
 
 
 [item-name]
+bob-turbo-loader=Turbo ładowarka
 bob-basic-loader=Podstawowa ładowarka
 
 

--- a/locale/ru/locale.cfg
+++ b/locale/ru/locale.cfg
@@ -5,20 +5,26 @@ vanilla-loaders-hd=Vanilla Loaders (Ванильные погрузчики)
 vanilla-loaders-hd=Добавляет в игру ванильные погрузчики с настраиваемым рецептом сложности. Поддерживает конвейеры, добавленные модами: "Bob's Logistics" и "Ultimate Belts".
 
 [entity-name]
+bob-turbo-loader=Турбо - погрузчик
+bob-ultimate-loader=Ультимативный погрузчик
 bob-basic-loader=Базовый погрузчик
 
 ub-ultra-fast-loader=Ультра-быстрый погрузчик
 ub-extreme-fast-loader=Экстремально-быстрый погрузчик
 ub-ultra-express-loader=Ультра-экспресс погрузчик
 ub-extreme-express-loader=Экстремально-экспресс погрузчик
+ub-ultimate-loader=Ультимативный погрузчик
 
 [item-name]
+bob-turbo-loader=Турбо - погрузчик
+bob-ultimate-loader=Ультимативный погрузчик
 bob-basic-loader=Базовый погрузчик
 
 ub-ultra-fast-loader=Ультра-быстрый погрузчик
 ub-extreme-fast-loader=Экстремально-быстрый погрузчик
 ub-ultra-express-loader=Ультра-экспресс погрузчик
 ub-extreme-express-loader=Экстремально-экспресс погрузчик
+ub-ultimate-loader=Ультимативный погрузчик
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Изменение рецептов

--- a/locale/ru/locale.cfg
+++ b/locale/ru/locale.cfg
@@ -5,7 +5,7 @@ vanilla-loaders-hd=Vanilla Loaders (Ванильные погрузчики)
 vanilla-loaders-hd=Добавляет в игру ванильные погрузчики с настраиваемым рецептом сложности. Поддерживает конвейеры, добавленные модами: "Bob's Logistics" и "Ultimate Belts".
 
 [entity-name]
-basic-loader=Базовый погрузчик
+bob-basic-loader=Базовый погрузчик
 
 ub-ultra-fast-loader=Ультра-быстрый погрузчик
 ub-extreme-fast-loader=Экстремально-быстрый погрузчик
@@ -13,7 +13,7 @@ ub-ultra-express-loader=Ультра-экспресс погрузчик
 ub-extreme-express-loader=Экстремально-экспресс погрузчик
 
 [item-name]
-basic-loader=Базовый погрузчик
+bob-basic-loader=Базовый погрузчик
 
 ub-ultra-fast-loader=Ультра-быстрый погрузчик
 ub-extreme-fast-loader=Экстремально-быстрый погрузчик

--- a/locale/ru/locale.cfg
+++ b/locale/ru/locale.cfg
@@ -5,26 +5,20 @@ vanilla-loaders-hd=Vanilla Loaders (Ванильные погрузчики)
 vanilla-loaders-hd=Добавляет в игру ванильные погрузчики с настраиваемым рецептом сложности. Поддерживает конвейеры, добавленные модами: "Bob's Logistics" и "Ultimate Belts".
 
 [entity-name]
-bob-turbo-loader=Турбо - погрузчик
-bob-ultimate-loader=Ультимативный погрузчик
 basic-loader=Базовый погрузчик
 
 ub-ultra-fast-loader=Ультра-быстрый погрузчик
 ub-extreme-fast-loader=Экстремально-быстрый погрузчик
 ub-ultra-express-loader=Ультра-экспресс погрузчик
 ub-extreme-express-loader=Экстремально-экспресс погрузчик
-ub-ultimate-loader=Ультимативный погрузчик
 
 [item-name]
-bob-turbo-loader=Турбо - погрузчик
-bob-ultimate-loader=Ультимативный погрузчик
 basic-loader=Базовый погрузчик
 
 ub-ultra-fast-loader=Ультра-быстрый погрузчик
 ub-extreme-fast-loader=Экстремально-быстрый погрузчик
 ub-ultra-express-loader=Ультра-экспресс погрузчик
 ub-extreme-express-loader=Экстремально-экспресс погрузчик
-ub-ultimate-loader=Ультимативный погрузчик
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Изменение рецептов

--- a/locale/uk/locale.cfg
+++ b/locale/uk/locale.cfg
@@ -5,20 +5,26 @@ vanilla-loaders-hd=Мод "Vanilla Loaders"
 vanilla-loaders-hd=Додає до гри ванільних навантажувачів зі складністю рецептів, що налаштовується. Підтримує конвеєри, додані в Bob's Logistics та Ultimate Belts.
 
 [entity-name]
+bob-turbo-loader=Турбо завантажувач
+bob-ultimate-loader=Ультимативний завантажувач
 bob-basic-loader=Базовий завантажувач
 
 ub-ultra-fast-loader=Ультра швидкий завантажувач
 ub-extreme-fast-loader=Екстремально швидкий завантажувач
 ub-ultra-express-loader=Ультра надшвидкий завантажувач
 ub-extreme-express-loader=Екстремально надшвидкий завантажувач
+ub-ultimate-loader=Ультимативний завантажувач
 
 [item-name]
+bob-turbo-loader=Турбо завантажувач
+bob-ultimate-loader=Ультимативний завантажувач
 bob-basic-loader=Базовий завантажувач
 
 ub-ultra-fast-loader=Ультра швидкий завантажувач
 ub-extreme-fast-loader=Екстремально швидкий завантажувач
 ub-ultra-express-loader=Ультра надшвидкий завантажувач
 ub-extreme-express-loader=Екстремально надшвидкий завантажувач
+ub-ultimate-loader=Ультимативний завантажувач
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Перероблення рецепту

--- a/locale/uk/locale.cfg
+++ b/locale/uk/locale.cfg
@@ -5,7 +5,7 @@ vanilla-loaders-hd=Мод "Vanilla Loaders"
 vanilla-loaders-hd=Додає до гри ванільних навантажувачів зі складністю рецептів, що налаштовується. Підтримує конвеєри, додані в Bob's Logistics та Ultimate Belts.
 
 [entity-name]
-basic-loader=Базовий завантажувач
+bob-basic-loader=Базовий завантажувач
 
 ub-ultra-fast-loader=Ультра швидкий завантажувач
 ub-extreme-fast-loader=Екстремально швидкий завантажувач
@@ -13,7 +13,7 @@ ub-ultra-express-loader=Ультра надшвидкий завантажува
 ub-extreme-express-loader=Екстремально надшвидкий завантажувач
 
 [item-name]
-basic-loader=Базовий завантажувач
+bob-basic-loader=Базовий завантажувач
 
 ub-ultra-fast-loader=Ультра швидкий завантажувач
 ub-extreme-fast-loader=Екстремально швидкий завантажувач

--- a/locale/uk/locale.cfg
+++ b/locale/uk/locale.cfg
@@ -5,26 +5,20 @@ vanilla-loaders-hd=Мод "Vanilla Loaders"
 vanilla-loaders-hd=Додає до гри ванільних навантажувачів зі складністю рецептів, що налаштовується. Підтримує конвеєри, додані в Bob's Logistics та Ultimate Belts.
 
 [entity-name]
-bob-turbo-loader=Турбо завантажувач
-bob-ultimate-loader=Ультимативний завантажувач
 basic-loader=Базовий завантажувач
 
 ub-ultra-fast-loader=Ультра швидкий завантажувач
 ub-extreme-fast-loader=Екстремально швидкий завантажувач
 ub-ultra-express-loader=Ультра надшвидкий завантажувач
 ub-extreme-express-loader=Екстремально надшвидкий завантажувач
-ub-ultimate-loader=Ультимативний завантажувач
 
 [item-name]
-bob-turbo-loader=Турбо завантажувач
-bob-ultimate-loader=Ультимативний завантажувач
 basic-loader=Базовий завантажувач
 
 ub-ultra-fast-loader=Ультра швидкий завантажувач
 ub-extreme-fast-loader=Екстремально швидкий завантажувач
 ub-ultra-express-loader=Ультра надшвидкий завантажувач
 ub-extreme-express-loader=Екстремально надшвидкий завантажувач
-ub-ultimate-loader=Ультимативний завантажувач
 
 [mod-setting-name]
 vanillaLoaders-recipes-loaderOverhaul=Перероблення рецепту


### PR DESCRIPTION
Since the prototypes use the entity name `bob-basic-loader` then the translations should follow the same naming convention.